### PR TITLE
save subjects finaled to localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 					</div>
 				</button>
 			</div>
-			<p class="text-black">Después de generar el grafo puedes ver los detalles y la relación directa entre cursos haciendo click en alguno, tambien puedes hacer zoom usando Ctrl+Scroll.</br>
+			<p class="text-black">Después de generar el grafo puedes ver los detalles y la relación directa entre cursos haciendo click en alguno, puedes marcar los cursos completados haciedo doble click y tambien puedes hacer zoom usando Ctrl+Scroll.</br>
 				Nota: La información aquí mostrada proviene completamente de datos públicos por parte de la universidad, esto podría poner en evidencia varias incoherencias en la manera como se tiene estructurado el plan de estudios de algunos programas.</p>
 		</div>
 		<h3 id="texto" class="text-black mb-1"></h3>

--- a/main.js
+++ b/main.js
@@ -23,6 +23,9 @@ const initRender = () => {
         node.findNodesInto().each((n) => n.isHighlighted = true);
         diagram.commitTransaction("highlight");
       },
+      doubleClick: (e, node) => {
+        changeCompleteSubject(node.qb.key);
+      },
       mouseEnter: (e, node) => {
         let shape = node.findObject("SHAPE");
         shape.stroke = "black";
@@ -34,10 +37,10 @@ const initRender = () => {
     },
     $(go.Shape, "RoundedRectangle",
       { strokeWidth: 3, stroke: null, name: "SHAPE" },
-      new go.Binding("fill", "isSelected", (sel) => sel ? "cyan" : "lightgreen").ofObject(),
-      new go.Binding("fill", "isHighlighted", (h) => h ? "orange" : "lightgreen").ofObject(),
+      new go.Binding("fill", "isSelected", (sel, node) => sel ? "cyan" : colorSubjectIsComplete(node?.yg?.qb?.key)).ofObject(),
+      new go.Binding("fill", "isHighlighted", (h, node) => h ? "orange" : colorSubjectIsComplete(node?.yg?.qb?.key)).ofObject(),
       new go.Binding("strokeWidth", "isHighlighted", (h) => h ? 5 : 3).ofObject(),
-      new go.Binding("stroke", "isHighlighted", (h) => h ? "red" : "lightgreen").ofObject()
+      new go.Binding("stroke", "isHighlighted", (h, node) => h ? "red" : colorSubjectIsComplete(node?.yg?.qb?.key)).ofObject()
     ),
     $(go.TextBlock, { margin: 10, font: "bold 18px Verdana" }, new go.Binding("text", "t"))
     );
@@ -57,6 +60,28 @@ const initRender = () => {
       if (!(part instanceof go.Link)) focusNode(part.data.key);
     });
   return myDiagram;
+}
+
+const subjectIsComplete = (subject) => {
+  const subjectsCompleteStr = localStorage.getItem("subjectsComplete");
+  const subjectsComplete = subjectsCompleteStr ? JSON.parse(subjectsCompleteStr) : [];
+  return subjectsComplete.includes(subject);
+}
+
+const changeCompleteSubject = (subject) => {
+  const subjectsCompleteStr = localStorage.getItem("subjectsComplete");
+  let subjectsComplete = subjectsCompleteStr ? JSON.parse(subjectsCompleteStr) : [];
+  if(subjectIsComplete(subject)){
+    const indexToDelete = subjectsComplete.indexOf(subject);
+    subjectsComplete.splice(indexToDelete, 1);
+  }else{
+    subjectsComplete.push(subject);
+  }
+  localStorage.setItem("subjectsComplete", JSON.stringify(subjectsComplete));
+}
+
+const colorSubjectIsComplete = (subject) => {
+  return subjectIsComplete(subject) ? "yellow" : "lightgreen";
 }
 
 const setEventListeners = () => {


### PR DESCRIPTION
# Permitir seleccionar las asignaturas ya completadas para visualizar el progreso. Con `dobleclick`


Antes:
<img width="958" alt="image" src="https://github.com/DavidCDCB/PlanesUC/assets/153309260/65796528-fc67-44e0-9192-b16c09119673">

Después:
<img width="960" alt="image" src="https://github.com/DavidCDCB/PlanesUC/assets/153309260/a657b5d4-3abc-4888-be51-b770f97f6505">
